### PR TITLE
#157931326 A user can view their own requests by request id

### DIFF
--- a/api/server/models.py
+++ b/api/server/models.py
@@ -65,6 +65,15 @@ def all_user_requests(user_email):
     return request
 
 
+def get_request_by_id(user_email, request_id):
+    """Method to update a previous request"""
+    # call the all requests method
+    dicts = all_user_requests(user_email)
+    result = next(
+        (item for item in dicts if item["request_id"] == request_id), False)
+    return result
+
+
 def check_email(search_email):
     """Check if email exists in USERS_LIST"""
     for find_email in USERS_LIST:

--- a/api/tests/test_requests.py
+++ b/api/tests/test_requests.py
@@ -38,10 +38,13 @@ class TestRequestEndpoint(BaseTestCase):
     def test_successful_request(self):
         """Test for successful request submission"""
         with self.client:
+            description = ("The description. This is the description. "
+                           "The description. This is the description. "
+                           "The description. This is the description. ")
             response = create_request(
                 self,
                 "This is the request title. Short and descriptive",
-                "The description. It has lengths that need to be adhered to. The description. It has lengths that need to be adhered to. The description. It has lengths that need to be adhered to. The description. It has lengths that need to be adhered to.",
+                description,
                 "user@mail.co"
             )
             data = json.loads(response.data.decode())
@@ -92,13 +95,16 @@ class TestRequestEndpoint(BaseTestCase):
 
         self.assertEqual(response.status_code, 400)
 
-    def test_successful_get_all_requests(self):
+    def test_successful_getall_requests(self):
         """Test for successful request submission"""
         with self.client:
+            description = ("The description. This is the description. "
+                           "The description. This is the description. "
+                           "The description. This is the description. ")
             create_request(
                 self,
                 "This is the request title. Short and descriptive",
-                "The description. It has lengths that need to be adhered to. The description. It has lengths that need to be adhered to. The description. It has lengths that need to be adhered to. The description. It has lengths that need to be adhered to.",
+                description,
                 "user@mail.co"
             )
             access_token = create_access_token('test@user.com')
@@ -108,6 +114,46 @@ class TestRequestEndpoint(BaseTestCase):
             response = self.client.get(
                 '/api/v1/users/requests', headers=headers)
             self.assertEqual(response.status_code, 200)
+
+    def test_get_request_byid(self):
+        """Test getting a users request by id"""
+        with self.client:
+            description = ("The description. This is the description. "
+                           "The description. This is the description. "
+                           "The description. This is the description. ")
+            create_request(
+                self,
+                "This is the request title. Short and descriptive",
+                description,
+                "user@mail.co"
+            )
+            access_token = create_access_token('test@user.com')
+            headers = {
+                'Authorization': 'Bearer {}'.format(access_token)
+            }
+            response = self.client.get(
+                '/api/v1/users/requests/1', headers=headers)
+            self.assertEqual(response.status_code, 200)
+
+    def test_get_request_byid_fail(self):
+        """Test getting a users request by id"""
+        with self.client:
+            description = ("The description. This is the description. "
+                           "The description. This is the description. "
+                           "The description. This is the description. ")
+            create_request(
+                self,
+                "This is the request title. Short and descriptive",
+                description,
+                "user@mail.co"
+            )
+            access_token = create_access_token('test@user.com')
+            headers = {
+                'Authorization': 'Bearer {}'.format(access_token)
+            }
+            response = self.client.get(
+                '/api/v1/users/requests/1234234', headers=headers)
+            self.assertEqual(response.status_code, 404)
 
     @pytest.mark.skip("We'll execute this test later")
     def test_get_request_by_id(self):


### PR DESCRIPTION
#### What does this PR do?
Allows a logged in user to view their specific request by the request id.
#### Description of Task to be completed?
-  **User view specific request.**
- Ensuring token is passed to the header.
- Ensure user can only view their own request.
#### How should this be manually tested?

```sh
$ git clone https://github.com/dalaineme/m-tracker.git
```
```sh
$ cd m-tracker
```
Create a virtual environment 
```sh
$ python3.6 -m venv venv
```
Activate a virtual environment 
```sh
$ source venv/bin/activate
```
Install project dependencies
```sh
$ pip install -r requirements.txt
```
Run the server
```sh
$ python run.py
```
Using postman, send a **GET** request to the URL _http://127.0.0.1:5000/api/v1/users/requests/<id>_
Refer to the screenshots below.

#### Any background context you want to provide?
Authorization header **MUST** be provided
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/157931326
####  Screenshots
###### Request ID doesn't exist in the request list for the specific user.
![1](https://user-images.githubusercontent.com/36375214/40835487-3ec6cd50-659c-11e8-9af6-0d6cdfcd104c.png)
###### Successful View of request by id 
![2_success](https://user-images.githubusercontent.com/36375214/40835532-62a590b2-659c-11e8-95c5-b91c99968dfb.png)
.
