### PR TITLE
#158050978 A user can delete their own requests

### DIFF
--- a/api/server/models.py
+++ b/api/server/models.py
@@ -82,6 +82,13 @@ def modify_user_request(user_email, request_id, title, description):
     result['date_updated'] = datetime.datetime.now()
 
 
+def delete_user_request(user_email, request_id):
+    """Method that deletes a user request by id"""
+    result = get_request_by_id(user_email, request_id)
+    # remove from list
+    REQUESTS_LIST.remove(result)
+
+
 def check_email(search_email):
     """Check if email exists in USERS_LIST"""
     for find_email in USERS_LIST:

--- a/api/server/request/views.py
+++ b/api/server/request/views.py
@@ -14,7 +14,8 @@ from flask_jwt_extended import (
 
 from api.server.request.schema import RequestSchema, ModifyRequestSchema
 from api.server.models import (
-    save_request, all_user_requests, get_request_by_id, modify_user_request)
+    save_request, all_user_requests, get_request_by_id, modify_user_request,
+    delete_user_request)
 
 # Create a blueprint
 REQUEST_BLUEPRINT = Blueprint('request', __name__, url_prefix='/api/v1/users/')
@@ -140,6 +141,26 @@ class RequestsAPI(MethodView):
         }
         return make_response(jsonify(response_object)), 201
 
+    @jwt_required
+    def delete(self, request_id=None):  # pylint: disable=R0201
+        """Send DELETE method to requests endpoint"""
+        current_user = get_jwt_identity()
+        specific_request = get_request_by_id(current_user, request_id)
+        # If request id not found
+        if not specific_request:
+            response_object = {
+                "status": 'fail',
+                "message": "Request ID not found."
+            }
+            return make_response(jsonify(response_object)), 404
+        # If request ID exists
+        delete_user_request(current_user, request_id)
+        response_object = {
+            "status": 'success',
+            "message": "Request has been deleted."
+        }
+        return make_response(jsonify(response_object)), 200
+
 
 # define API resources
 REQUESTS_VIEW = RequestsAPI.as_view('requests_api')
@@ -153,5 +174,5 @@ REQUEST_BLUEPRINT.add_url_rule(
 REQUEST_BLUEPRINT.add_url_rule(
     '/requests/<int:request_id>',
     view_func=REQUESTS_VIEW,
-    methods=['GET', 'PUT']
+    methods=['GET', 'PUT', 'DELETE']
 )

--- a/api/tests/test_requests.py
+++ b/api/tests/test_requests.py
@@ -211,6 +211,30 @@ class TestRequestEndpoint(BaseTestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_delete_noexist(self):
+        """Test deleting a request which does not exist"""
+
+        access_token = create_access_token('test@user.com')
+        headers = {
+            'Authorization': 'Bearer {}'.format(access_token)
+        }
+        response = self.client.delete(
+            '/api/v1/users/requests/123382311', headers=headers)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_successful_delete(self):
+        """Test success deleting a request"""
+
+        access_token = create_access_token('test@user.com')
+        headers = {
+            'Authorization': 'Bearer {}'.format(access_token)
+        }
+        response = self.client.delete(
+            '/api/v1/users/requests/1', headers=headers)
+
+        self.assertEqual(response.status_code, 200)
+
     @pytest.mark.skip("We'll execute this test later")
     def test_get_request_by_id(self):
         """Test if user can get request by id"""


### PR DESCRIPTION
#### What does this PR do?
Allows a logged in user to delete their previously made request.
#### Description of Task to be completed?
-  **User delete request.**
- Ensuring token is passed to the header.
- Ensure user can only delete their own request.
#### How should this be manually tested?

```sh
$ git clone https://github.com/dalaineme/m-tracker.git
```
```sh
$ cd m-tracker
```
Create a virtual environment 
```sh
$ python3.6 -m venv venv
```
Activate a virtual environment 
```sh
$ source venv/bin/activate
```
Install project dependencies
```sh
$ pip install -r requirements.txt
```
Run the server
```sh
$ python run.py
```
Using postman, send a **DELETE** request to the URL _http://127.0.0.1:5000/api/v1/users/requests/<id>_
Refer to the screenshots below.

#### Any background context you want to provide?
Authorization header **MUST** be provided
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/158050978
####  Screenshots
###### Request doesn't exist.

![1_req_id_not_found](https://user-images.githubusercontent.com/36375214/40877677-7aca0280-668d-11e8-8311-43ee0c3e95a8.png)
###### Successful Request Deletion
![1_success_delete](https://user-images.githubusercontent.com/36375214/40877679-83df37e6-668d-11e8-85ed-ffdac665634d.png)

