### PR TITLE
#158138239 A logged in user can view their own requests by request ID

### DIFF
--- a/api/server/request/models.py
+++ b/api/server/request/models.py
@@ -6,7 +6,7 @@ This module contains functions that are used in the auth endpoint
 import sys
 import psycopg2
 from db_conn import DbConn
-from api.server.helpers import json_fetch_all, get_query
+from api.server.helpers import get_query
 
 
 # def create_request(input_title, input_description, user_id):
@@ -51,3 +51,12 @@ def all_user_requests(user_id):
              "AND tbl_requests.created_by = %s;")
     user_reqeusts = get_query(query, user_id)
     return user_reqeusts
+
+
+def get_request_by_id(user_id, request_id):
+    """Method to update a previous request"""
+    # call the all requests method
+    dicts = all_user_requests(user_id)
+    result = next(
+        (item for item in dicts if item["request_id"] == request_id), False)
+    return result

--- a/api/tests/base.py
+++ b/api/tests/base.py
@@ -14,7 +14,8 @@ def truncate_tables():
     db_instance.conn.autocommit = True
     try:
         with db_instance.conn.cursor() as cursor:
-            cursor.execute("TRUNCATE tbl_users, tbl_requests CASCADE;")
+            cursor.execute("TRUNCATE tbl_users CASCADE;")
+            cursor.execute("TRUNCATE tbl_requests CASCADE;")
             db_instance.conn.close()
     except psycopg2.Error:
         raise SystemExit(

--- a/api/tests/base.py
+++ b/api/tests/base.py
@@ -14,8 +14,8 @@ def truncate_tables():
     db_instance.conn.autocommit = True
     try:
         with db_instance.conn.cursor() as cursor:
-            cursor.execute("TRUNCATE tbl_users CASCADE;")
-            cursor.execute("TRUNCATE tbl_requests CASCADE;")
+            cursor.execute("TRUNCATE tbl_users RESTART IDENTITY CASCADE;")
+            cursor.execute("TRUNCATE tbl_requests RESTART IDENTITY CASCADE;")
             db_instance.conn.close()
     except psycopg2.Error:
         raise SystemExit(

--- a/api/tests/test_requests.py
+++ b/api/tests/test_requests.py
@@ -135,6 +135,7 @@ class TestRequestEndpoint(BaseTestCase):
 
     def test_request_exist(self):
         """Test for existing request by specific id"""
+        create_user()
         create_request(
             self,
             "This is the request title. Short and descriptive",
@@ -153,6 +154,22 @@ class TestRequestEndpoint(BaseTestCase):
         }
         response = self.client.get(
             URL_PREFIX + 'requests/1', headers=headers)
+        self.assertEqual(response.status_code, 200)
+        truncate_tables()
+
+    def test_request_dont_exist(self):
+        """Test for non existing request by specific id"""
+        create_user()
+        user = {
+            "user_id": "988",
+            "user_level": "User"
+        }
+        access_token = create_access_token(identity=user)
+        headers = {
+            'Authorization': 'Bearer {}'.format(access_token)
+        }
+        response = self.client.get(
+            URL_PREFIX + 'requests/1999', headers=headers)
         self.assertEqual(response.status_code, 404)
         truncate_tables()
 


### PR DESCRIPTION
#### What does this PR do?
Allows a logged in user to view their specific request by the request id.
#### Description of Task to be completed?
-  **User view specific request.**
- Ensuring token is passed to the header.
- Ensure user can only view their own request.
#### How should this be manually tested?

```sh
$ git clone https://github.com/dalaineme/m-tracker.git
```
```sh
$ cd m-tracker
```
Create a virtual environment 
```sh
$ python3.6 -m venv venv
```
Activate a virtual environment 
```sh
$ source venv/bin/activate
```
Install project dependencies
```sh
$ pip install -r requirements.txt
```
Run the server
```sh
$ python run.py
```
Using postman, send a **GET** request to the URL _http://127.0.0.1:5000/api/v1/users/requests/<id>_
Refer to the screenshots below.

#### Any background context you want to provide?
Authorization header **MUST** be provided
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/157931326
####  Screenshots
###### Request ID doesn't exist in the request list for the specific user.
![1](https://user-images.githubusercontent.com/36375214/40835487-3ec6cd50-659c-11e8-9af6-0d6cdfcd104c.png)
###### Successful View of request by id 
![2_success](https://user-images.githubusercontent.com/36375214/40835532-62a590b2-659c-11e8-95c5-b91c99968dfb.png)
.
