### PR TITLE
#158236832 A logged in user can delete their own requests

### DIFF
--- a/api/server/request/models.py
+++ b/api/server/request/models.py
@@ -9,14 +9,6 @@ from db_conn import DbConn
 from api.server.helpers import get_query, run_query
 
 
-# def create_request(input_title, input_description, user_id):
-#     """Create a new user request"""
-#     query = (u"INSERT INTO tbl_requests (request_title, request_description, "
-#              "created_by) VALUES (%s, %s, %s);")
-#     inputs = input_title, input_description, user_id
-#     # run query
-#     run_query(query, inputs)
-
 def create_request(input_title, input_description, user_id):
     """Create a new user request"""
     try:
@@ -60,7 +52,12 @@ def get_request_by_id(user_id, request_id):
     dicts = all_user_requests(user_id)
     result = next(
         (item for item in dicts if item["request_id"] == request_id), False)
-    query = ("SELECT tbl_status_logs.request_status,tbl_status_logs.date_updated, tbl_status_logs.request, tbl_requests.request_id FROM tbl_requests, tbl_status_logs WHERE tbl_status_logs.request=tbl_requests.request_id AND tbl_requests.request_id=%s;")
+    query = ("SELECT tbl_status_logs.request_status, "
+             "tbl_status_logs.date_updated, tbl_status_logs.request, "
+             "tbl_requests.request_id FROM tbl_requests, "
+             "tbl_status_logs WHERE tbl_status_logs.request "
+             " =tbl_requests.request_id AND "
+             "tbl_requests.request_id=%s;")
     if result:
         request_logs = get_query(query, result["request_id"])
         response_dict = {
@@ -84,5 +81,20 @@ def modify_user_request(user_id, request_id, title, description):
     query = (u"UPDATE tbl_requests SET request_title=%s, "
              "request_description=%s WHERE request_id=%s AND created_by=%s ;")
     inputs = title, description, request_id, user_id
+    # run query
+    return run_query(query, inputs)
+
+
+def delete_request(user_id, request_id):
+    """Method that deletes a user request by id"""
+    result = get_request_by_id(user_id, request_id)
+    if result["current_status"] != "Sent":
+        return "fail"
+    # remove from DB
+    query1 = (u"DELETE FROM tbl_status_logs WHERE request = %s;")
+    inputs1 = str(request_id)
+    run_query(query1, inputs1)
+    query = (u"DELETE FROM tbl_requests WHERE request_id=%s;")
+    inputs = str(request_id)
     # run query
     return run_query(query, inputs)

--- a/api/server/request/models.py
+++ b/api/server/request/models.py
@@ -88,7 +88,7 @@ def modify_user_request(user_id, request_id, title, description):
 def delete_request(user_id, request_id):
     """Method that deletes a user request by id"""
     result = get_request_by_id(user_id, request_id)
-    if result["current_status"] != "Sent":
+    if result["current_status"] == "Approved":
         return "fail"
     # remove from DB
     query1 = (u"DELETE FROM tbl_status_logs WHERE request = %s;")

--- a/api/server/request/views.py
+++ b/api/server/request/views.py
@@ -163,8 +163,8 @@ class RequestsAPI(MethodView):
                 "status": 'fail',
                 "msg": "You can not delete an Approved request."
             }
-            return make_response(jsonify(response_object)), 401
-
+            return make_response(jsonify(response_object)), 403
+        # Successful deletion
         response_object = {
             "status": 'success',
             "msg": "Your request has been deleted."

--- a/api/server/request/views.py
+++ b/api/server/request/views.py
@@ -13,7 +13,8 @@ from flask_jwt_extended import (
 
 from api.server.request.schema import RequestSchema, ModifyRequestSchema
 from api.server.request.models import (
-    create_request, all_user_requests, get_request_by_id, modify_user_request)
+    create_request, all_user_requests, get_request_by_id, modify_user_request,
+    delete_request)
 
 # Create a blueprint
 REQUEST_BLUEPRINT = Blueprint('request', __name__, url_prefix='/api/v1/users/')
@@ -141,6 +142,32 @@ class RequestsAPI(MethodView):
         response_object = {
             "status": 'success',
             "msg": "Your request has been updated."
+        }
+        return make_response(jsonify(response_object)), 201
+
+    @jwt_required
+    def delete(self, request_id=None):  # pylint: disable=R0201
+        """Send DELETE method to requests endpoint"""
+        user_id = get_jwt_identity()
+        specific_request = get_request_by_id(user_id, request_id)
+        # If request id not found
+        if specific_request == "fail":
+            response_object = {
+                "status": 'fail',
+                "msg": "Request ID not found."
+            }
+            return make_response(jsonify(response_object)), 404
+        result = delete_request(user_id, request_id)
+        if result == "fail":
+            response_object = {
+                "status": 'fail',
+                "msg": "You can not delete an Approved request."
+            }
+            return make_response(jsonify(response_object)), 401
+
+        response_object = {
+            "status": 'success',
+            "msg": "Your request has been deleted."
         }
         return make_response(jsonify(response_object)), 201
 


### PR DESCRIPTION
#### What does this PR do?
Allows a logged in user to delete their previously made request.
#### Description of Task to be completed?
-  **User delete request.**
- Ensuring token is passed to the header.
- Ensure user can only delete their own request.
#### How should this be manually tested?

```sh
$ git clone https://github.com/dalaineme/m-tracker.git
```
```sh
$ cd m-tracker
```
Create a virtual environment 
```sh
$ python3.6 -m venv venv
```
Activate a virtual environment 
```sh
$ source venv/bin/activate
```
Install project dependencies
```sh
$ pip install -r requirements.txt
```
Run the server
```sh
$ python run.py
```
Using postman, send a **DELETE** request to the URL _http://127.0.0.1:5000/api/v1/users/requests/<id>_
Refer to the screenshots below.

#### Any background context you want to provide?
Authorization header **MUST** be provided
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/158050978
####  Screenshots
###### Request doesn't exist.

![1_req_id_not_found](https://user-images.githubusercontent.com/36375214/40877677-7aca0280-668d-11e8-8311-43ee0c3e95a8.png)
###### Successful Request Deletion
![1_success_delete](https://user-images.githubusercontent.com/36375214/40877679-83df37e6-668d-11e8-85ed-ffdac665634d.png)

